### PR TITLE
Handle error with no response object

### DIFF
--- a/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
@@ -446,14 +446,17 @@ class ApiClient {
         return new Promise((resolve, reject) => {
             request.end((error, response) => {
                 if (error) {
-                    var err = {};
-                    err.status = response.status;
-                    err.statusText = response.statusText;
-                    err.body = response.body;
-                    err.response = response;
-                    err.error = error;
+                     if(response) {
+                        var err = {};
+                        err.status = response.status;
+                        err.statusText = response.statusText;
+                        err.body = response.body;
+                        err.response = response;
+                        err.error = error;
+                        reject(err);
+                    }
 
-                    reject(err);
+                    reject(error);
                 } else {
                     try {
                         var data = this.deserialize(response, returnType);

--- a/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
@@ -446,7 +446,7 @@ class ApiClient {
         return new Promise((resolve, reject) => {
             request.end((error, response) => {
                 if (error) {
-                     if(response) {
+                     if (response) {
                         var err = {};
                         err.status = response.status;
                         err.statusText = response.statusText;
@@ -454,6 +454,7 @@ class ApiClient {
                         err.response = response;
                         err.error = error;
                         reject(err);
+                        return;
                     }
 
                     reject(error);


### PR DESCRIPTION
Where there is no response, this causes an error:
TypeError: Cannot read property 'status' of undefined

### PR checklist

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh`, `./bin/openapi3/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`. If contributing template-only or documentation-only changes which will change sample output, be sure to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) first.
- [x] Filed the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `4.1.x`, `5.0.x`. Default: `master`.
- [x] Copied the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

Where there is no response, this causes an error:
TypeError: Cannot read property 'status' of undefined

To reproduce, make a request to an API that doesn't exist.
